### PR TITLE
WorldCharacterManager

### DIFF
--- a/SDK/Basic_Functions.cpp
+++ b/SDK/Basic_Functions.cpp
@@ -11,18 +11,26 @@
 namespace HEXINTON
 {
 
+	GameManager* CGlobals::GGameMan;
+	GameDataManager* CGlobals::GGameDataMan;
+	WorldCharacterManager* CGlobals::GWorldCharMan;
+
 	//---------------------------------------------------------------------------------------------------
 	// 
 	//	----------	[SECTION] GLOBALS
 	//
 	//---------------------------------------------------------------------------------------------------
 
-    bool InitSdk() { return InitSdk("EldenRing.exe"); }
-	bool InitSdk(const std::string& moduleName)
+    bool InitSdk() { return InitSdk("EldenRing.exe", 0x3CE0708, 0x3CD4D88, 0x3CDCDD8); }
+	bool InitSdk(const std::string& moduleName, uintptr_t gGameMan, uintptr_t gGameDataMan, uintptr_t gWorldCharMan)
 	{
 		auto mBaseAddress = reinterpret_cast<uintptr_t>(GetModuleHandleA(moduleName.c_str()));
 		if (!mBaseAddress)
 			return false;
+
+		CGlobals::GGameMan = reinterpret_cast<HEXINTON::GameManager*>(*(reinterpret_cast<__int64*>(mBaseAddress + gGameMan)));
+		CGlobals::GGameDataMan = reinterpret_cast<HEXINTON::GameDataManager*>(*(reinterpret_cast<__int64*>(mBaseAddress + gGameDataMan)));
+		CGlobals::GWorldCharMan = reinterpret_cast<HEXINTON::WorldCharacterManager*>(*(reinterpret_cast<__int64*>(mBaseAddress + gWorldCharMan)));
 
 		return TRUE;
 	}

--- a/SDK/Basic_Functions.h
+++ b/SDK/Basic_Functions.h
@@ -16,7 +16,7 @@ namespace HEXINTON
 	// --------------------------------------------------
 	// # Global functions
 	// --------------------------------------------------
-	bool InitSdk(const std::string& moduleName);
+	bool InitSdk(const std::string& moduleName, uintptr_t gGameMan, uintptr_t gGameDataMan, uintptr_t gWorldCharMan);
 	bool InitSdk();
 	void ShutdownSdk();
 

--- a/SDK/EldenRing_Classes.h
+++ b/SDK/EldenRing_Classes.h
@@ -9,189 +9,173 @@
 #pragma pack(push, 0x01)
 namespace HEXINTON
 {
-    class ChrPhysics 
-    {
-    public:
-		char                pad_0000[84];					//0x0000
-		float               Azimuth;						//0x0054
-		char                pad_0058[24];					//0x0058
-        Vector3             Pos;							//
-        char                pad2[0x157];					//
-        bool                GravityEnabled;					//
-    };
-
-    class UnitData 
-    {
-    public:
-        char                pad[0x138];                     // 0x0
-        uint32_t            Health;                         // 0x138
-        uint32_t            pad2;                           // 0x13C
-        uint32_t            MaxHealth;                      // 0x140
-        uint32_t            BaseMaxHealth;                  // 0x144
-        uint32_t            mana;                           // 0x148
-        uint32_t            maxmana;                        // 0x14C
-        uint32_t            basemaxmana;                    // 0x150
-        uint32_t            stamina;                        // 0x154
-        uint32_t            maxstamina;                     // 0x158
-        uint32_t            basemaxstamina;                 // 0x15C
-    };
-
-    class ChrModules 
-    {
-    public:
-        class UnitData*     UnitData;
-        uint64_t            actionflag;
-        uint64_t            behaviorscript;
-        uint64_t            timeact;
-        uint64_t            resist;
-        uint64_t            behavior;
-        uint64_t            behaviorsync;
-        uint64_t            ai;
-        uint64_t            playersuperarmor;
-        uint64_t            playertoughness;
-        uint64_t            talk;
-        uint64_t            event;
-        uint64_t            playermagic;
-        class ChrPhysics*   Physics;
-        uint64_t            fall;
-        uint64_t            playerladder;
-        uint64_t            actionrequest;
-        uint64_t            chrthrow;
-        uint64_t            hitstop;
-        uint64_t            playerdamage;
-        uint64_t            playermaterial;
-        uint64_t            playerknockback;
-        uint64_t            sfx;
-        uint64_t            vfx;
-        uint64_t            behaviordata;
-    };
-
-	class FaceData 
-    {
-	public:
-		uint32_t            FaceModelId;
-		uint32_t            HairModelId;
-		uint32_t            EyeModelId;
-		uint32_t            EyebrowModelId;
-		uint32_t            BeardModelId;
-		uint32_t            AccModelId;
-		uint32_t            DecalModelId;
-		uint32_t            EyelashModelId;
-	};
-
-	struct ChrStats 
-    {
-	public:
-		uint32_t            Vigor;                          // 0x0
-		uint32_t            Mind;                           // 0x4
-		uint32_t            Endurance;                      // 0x8
-		uint32_t            Strength;                       // 0xC
-		uint32_t            Dexterity;                      // 0x10
-		uint32_t            Intelligence;                   // 0x14
-		uint32_t            Faith;                          // 0x18
-		uint32_t            Arcane;                         // 0x1C
-	};
-
-	struct ChrAsm 
-    {
-	public:
-		uint8_t             ArmStyle;                       // 0x328 (GameData + 0x328)
-		uint8_t             pad[3];                         // 0x329
-		uint32_t            CurrentWepSlotOffsetL;          // 0x32C
-		uint32_t            CurrentWepSlotOffsetR;          // 0x330
-		uint32_t            CurrentWepSlotOffsetLArrow;     // 0x334
-		uint32_t            CurrentWepSlotOffsetRArrow;     // 0x338
-		uint32_t            CurrentWepSlotOffsetLBolt;      // 0x33C
-		uint32_t            CurrentWepSlotOffsetRBolt;      // 0x340
-		char                pad2[0x44];                     // 0x344
-		uint32_t            Accessory1;                     // 0x388
-		uint32_t            Accessory2;                     // 0x38C
-		uint32_t            Accessory3;                     // 0x390
-		uint32_t            Accessory4;                     // 0x394
-		uint32_t            Accessory5;                     // 0x398
-		uint32_t            PrimaryWeaponL;                 // 0x39C
-		uint32_t            PrimaryWeaponR;                 // 0x3A0
-		uint32_t            SecondaryWeaponL;               // 0x3A4
-		uint32_t            SecondaryWeaponR;               // 0x3A8
-		uint32_t            TertiaryWeaponL;                // 0x3AC
-		uint32_t            TertiaryWeaponR;                // 0x3B0
-		uint32_t            PrimaryArrow;                   // 0x3B4
-		uint32_t            PrimaryBolt;                    // 0x3B8
-		uint32_t            SecondaryArrow;                 // 0x3BC
-		uint32_t            SecondaryBolt;                  // 0x3C0
-		uint32_t            TertiaryArrow;                  // 0x3C4
-		uint32_t            TertiaryBolt;                   // 0x3C8
-		uint32_t            Helmet;                         // 0x3CC
-		uint32_t            Chest;                          // 0x3D0
-		uint32_t            Gloves;                         // 0x3D4
-		uint32_t            Legs;                           // 0x3D8
-		uint32_t            Hair;                           // 0x3DC
-	};
-
-	class ChrGameData 
-    {
-	public:
-		char                pad[0x10];                      // 0x0
-		uint32_t            Health;                         // 0x10
-		uint32_t            MaxHealth;                      // 0x14
-		uint32_t            BaseMaxHealth;                  // 0x18
-		uint32_t            Mana;                           // 0x1C
-		uint32_t            MaxMana;                        // 0x20
-		uint32_t            BaseMaxMana;                    // 0x24
-		uint32_t            unk;                            // 0x28
-		uint32_t            Stamina;                        // 0x2C
-		uint32_t            MaxStamina;                     // 0x30
-		uint32_t            BaseMaxStamina;                 // 0x34
-		uint32_t            unk_;                           // 0x38
-		class ChrStats      Stats;                          // 0x3C
-		int                 pad2[2];                        // 0x58
-		uint32_t            RuneArc;                        // 0x64
-		uint32_t            Level;                          // 0x68
-		uint32_t            CurrentRunes;                   // 0x6C
-		uint32_t            TotalRunes;                     // 0x70
-		int                 unk2;                           // 0x74
-		uint32_t            Immunity1;                      // 0x78
-		uint32_t            Immunity2;                      // 0x7C
-		uint32_t            Robustness;                     // 0x80
-		uint32_t            Vitality;                       // 0x84
-		uint32_t            Robustness2;                    // 0x88
-		uint32_t            Focus;                          // 0x8C
-		uint32_t            Focus2;                         // 0x90
-		int                 pad3[2];                        // 0x94
-		char                Name[19];                       // 0x9C
-		char                pad4[0xF];                      // 0xAF
-		PlayerGender		Gender;                         // 0xBE
-		PlayerClass			Class;                          // 0xBF
-		uint8_t             Appearance;                     // 0xC0
-		uint8_t             unk3;                           // 0xC1
-		uint8_t             Voice;                          // 0xC2
-		uint8_t             StartingGift;                   // 0xC3
-		char                pad5[0x3B];                     // 0xC4;
-		uint8_t             GreaterRuneState;               // 0xFF
-		char                unk_ad6[0x228];                 // 0x100
-		class ChrAsm        ChrAsm;                         // 0x328
-	};
-
-    class ChrIns
+	// Template class for obtaining globals
+	class CGlobals
 	{
 	public:
-		uint64_t            _;
-		uint32_t            LocalId;                        // 0x8
-		char                pad[0x54];                      // 0xC
-		uint32_t            ParamId;                        // 0x60
-		uint32_t            pad2[2];                        // 0x64
-		uint8_t             TeamId;                         // 0x6C
-		char                pad3[0x7];                      // 0x6D
-		uint32_t            GlobalId;                       // 0x74
-		char                pad4[0x118];                    // 0x78
-		class ChrModules*   Modules;                        // 0x190
+		static class GameManager*				GGameMan;
+		static class GameDataManager*			GGameDataMan;
+		static class WorldCharacterManager*		GWorldCharMan;
+	};
+
+	class GameManager
+	{
+	private:
+
+	};
+
+	class GameDataManager
+	{
+	private:
+
+	};
+
+	class WorldCharacterManager
+	{
+	private:	
+		char							pad_0008[69360];		//0x0008
+		class LocalPlayer*				pLocalPlayer;			//0x10EF8
+	
+	private:
+		virtual void					Function0();
 
 	public:
-		uint32_t			GetHP();
-		uint32_t			GetMaxHP();
-		Vector3				GetPos();
-		void				SetPos(Vector3 In);
-		float				GetDistance(Vector3 Other);
-	};
+		LocalPlayer*					GetLocalPlayer();
+	};	//Size: 0x10F00
+
+	class LocalPlayer
+	{
+	private:
+		class PlayerInstance*			pPlayer;				//0x0000
+		int32_t							dwflag;					//0x0008
+
+	public:
+		PlayerInstance*					GetPlayerInstance();
+	};	//Size: 0x000C
+
+	class PlayerInstance
+	{
+	private:
+		int32_t							HandleID;				//0x0008
+		char							pad_000C[4];			//0x000C
+		class LocalPlayer*				pLocalPlayer;			//0x0010
+		char							pad_0018[16];			//0x0018
+		class CharRes*					pCharRes;				//0x0028
+		char							pad_0030[32];			//0x0030
+		class CSCharModelIns*			pCharModelInstance;		//0x0050
+		class CSPlayerCtrl*				pPlayerCtrl;			//0x0058
+		char							pad_0060[8];			//0x0060
+		int32_t							CharacterType;			//0x0068
+		int32_t							TeamType;				//0x006C
+		char							pad_0070[80];			//0x0070
+		class CSTargetVelocityRecorder*	pTargetVelocityRecorder;	//0x00C0
+		char							pad_00C8[40];			//0x00C8
+		class PlayerInstance*			pPlayerInstance;		//0x00F0
+		char							pad_00F8[128];			//0x00F8
+		class CSSpecialEffect*			pSpecialEffects;		//0x0178
+		char							pad_0180[8];			//0x0180
+		int32_t							CharacterID;			//0x0188
+		char							pad_018C[4];			//0x018C
+		class CharacterModules*			pCharModules;			//0x0190
+
+
+	private:
+		virtual void Function0();
+
+	public:
+		CharacterModules*				GetCharacterModules();
+		int32_t							GetCharType();
+		int32_t							GetTeam();
+		void							SetCharType(const int32_t newType);
+		void							SetTeam(const int32_t newTeam);
+		bool							GetHP(int32_t& outHealth);
+		bool							GetPos(Vector3& outPos);
+		float							GetDistance(const Vector3 Other);
+		void							SetHP(const int32_t value);
+		void							SetPos(const Vector3 In);
+	};	//Size: 0x0198
+
+	class CharacterModules
+	{
+	private:
+		class CSCharData*				pCharData;				//0x0000
+		class CSCharActionFlags*		pCharActionFlags;		//0x0008
+		class CSCharBehaviorScripts*	pCharBehavScripts;		//0x0010
+		class CSCharTimeAct*			pCharTimeAct;			//0x0018
+		class CSCharResist*				pCharResist;			//0x0020
+		class CSCharBehavior*			pCharBehavior;			//0x0028
+		class CSCharBehaviorSync*		pCharBehaviorSync;		//0x0030
+		class CSCharAi*					pCharAI;				//0x0038
+		class CSPlayerSuperArmor*		pCharSuperArmor;		//0x0040
+		class CSPlayerToughness*		pPlayerToughness;		//0x0048
+		class CSCharTalk*				pCharTalk;				//0x0050
+		class CSCharEvent*				pCharEvent;				//0x0058
+		class CSPlayerMagic*			pPlayerMagic;			//0x0060
+		class CSCharPhysics*			pCharPhysics;			//0x0068
+		class CSCharFall*				pCharFall;				//0x0070
+		class CSPlayerLadder*			PlayerLadder;			//0x0078
+		class CSCharActionRequest*		pCharActionRequest;		//0x0080
+		class CSCharThrow*				pCharThrow;				//0x0088
+		class CSCharHitStop*			pCharHitStop;			//0x0090
+		class CSPlayerDamage*			pPlayerDamage;			//0x0098
+
+	public:
+		CSCharData*						GetCharData();
+		CSCharPhysics*					GetCharPhysics();
+		CSPlayerDamage*					GetPlayerDamage();
+	};	//Size: 0x00A0
+	
+	class CSCharData
+	{
+	private:
+		char							pad_0008[304];			//0x0008
+		int32_t							CurrentHealth;			//0x0138
+		int32_t							N000035E3;				//0x013C
+		int32_t							MaxHealth;				//0x0140
+		int32_t							BaseMaxHealth;			//0x0144
+		int32_t							CurrentMana;			//0x0148
+		int32_t							MaxMana;				//0x014C
+		int32_t							BaseMaxMana;			//0x0150
+		int32_t							CurrentStamina;			//0x0154
+		int32_t							MaxStamina;				//0x0158
+		int32_t							BaseMaxStamina;			//0x015C
+
+	private:
+		virtual void Function0();
+
+	public:
+		int32_t							GetHealth();
+		void							SetHealth(const int32_t& value);
+		int32_t							GetMana();
+		void							SetMana(const int32_t& value);
+		int32_t							GetStamina();
+		void							SetStamina(const int32_t& value);
+	};	//Size: 0x0160
+
+	class CSCharPhysics
+	{
+	private:
+		class PlayerInstance*			pPlayerInstance;		//0x0008
+		class PlayerInstance*			pPlayerInstance2;		//0x0010
+		class CSCharPhysics*			pCharPhysics;			//0x0018
+		class CSCharData*				pCharData;				//0x0020
+		class hknpCapsuleShape*			pHKCapsule;				//0x0028
+		char							pad_0030[36];			//0x0030
+		float							sinAzimuth;				//0x0054
+		char							pad_0058[4];			//0x0058
+		float							cosAzimuth;				//0x005C
+		char							pad_0060[16];			//0x0060
+		Vector3							RelativePosition;		//0x0070
+		char							pad_007C[343];			//0x007C
+		bool							bNoGravity;				//0x01D3
+
+	private:
+		virtual void Function0();
+
+	public:
+		Vector3							GetLocalPosition();
+		void							SetLocalPosition(Vector3 newPosition);
+		void							ToggleGravity();
+	};	//Size: 0x01D4
 }
 #pragma pack(pop)

--- a/SDK/EldenRing_Functions.cpp
+++ b/SDK/EldenRing_Functions.cpp
@@ -10,70 +10,115 @@
 #pragma pack(push, 0x01)
 namespace HEXINTON
 {
-	uint32_t ChrIns::GetHP()
+	//	WorldCharacterManager
+	LocalPlayer* WorldCharacterManager::GetLocalPlayer() { return this->pLocalPlayer; }
+
+	//	LocalPlayer
+	PlayerInstance* LocalPlayer::GetPlayerInstance() { return this->pPlayer; }
+
+	//	PlayerInstance
+	CharacterModules* PlayerInstance::GetCharacterModules() { return this->pCharModules; }
+	int32_t	PlayerInstance::GetCharType() { return this->CharacterType; }
+	int32_t	PlayerInstance::GetTeam() { return this->TeamType; }
+	void PlayerInstance::SetCharType(const int32_t newType) { this->CharacterType = newType; }
+	void PlayerInstance::SetTeam(const int32_t newTeam) { this->TeamType = newTeam; }
+
+	bool PlayerInstance::GetHP(int32_t& outHealth)
 	{
+		bool result = FALSE;
+
 		// Get Modules
-		ChrModules* modules = this->Modules;
+		CharacterModules* modules = this->pCharModules;
 		if (modules == nullptr)
-			return -1;
+			return result;
 
 		// Obtain Unit Data
-		UnitData* unitData = modules->UnitData;
-		if (unitData == nullptr)
-			return -1;
+		CSCharData* charData = modules->GetCharData();
+		if (charData == nullptr)
+			return result;
 
 		//	Get Current Health
-		return unitData->Health;
+		outHealth = charData->GetHealth();
+		return TRUE;
 	}
 
-	uint32_t ChrIns::GetMaxHP()
+	void PlayerInstance::SetHP(int32_t value)
 	{
+		bool result = FALSE;
+
 		// Get Modules
-		ChrModules* modules = this->Modules;
+		CharacterModules* modules = this->pCharModules;
 		if (modules == nullptr)
-			return -1;
+			return;
 
 		// Obtain Unit Data
-		UnitData* unitData = modules->UnitData;
-		if (unitData == nullptr)
-			return -1;
+		CSCharData* charData = modules->GetCharData();
+		if (charData == nullptr)
+			return;
 
-		return unitData->MaxHealth;
+		//	Get Current Health
+		charData->SetHealth(value);
 	}
 
-	Vector3 ChrIns::GetPos()
+	bool PlayerInstance::GetPos(Vector3& out)
 	{
+		bool result = FALSE;
+
 		// Get Modules
-		ChrModules* modules = this->Modules;
+		CharacterModules* modules = this->pCharModules;
 		if (modules == nullptr)
-			return { 0, 0, 0 };
+			return result;
 
 		// Obtain physics
-		ChrPhysics* physics = modules->Physics;
+		CSCharPhysics* physics = modules->GetCharPhysics();
 		if (physics == nullptr)
-			return { 0, 0, 0 };
+			return result;
 
-		return physics->Pos;
+		out = physics->GetLocalPosition();
+		return TRUE;
 	}
 
-	void ChrIns::SetPos(Vector3 In)
+	void PlayerInstance::SetPos(Vector3 In)
 	{
+		bool result = FALSE;
+
 		// Get Modules
-		ChrModules* modules = this->Modules;
+		CharacterModules* modules = this->pCharModules;
 		if (modules == nullptr)
 			return;
 
 		// Obtain physics
-		ChrPhysics* physics = modules->Physics;
+		CSCharPhysics* physics = modules->GetCharPhysics();
 		if (physics == nullptr)
 			return;
 
-		physics->Pos = In;
+		physics->SetLocalPosition(In);
 	}
 
-	float ChrIns::GetDistance(Vector3 Other)
+	float PlayerInstance::GetDistance(Vector3 Other)
 	{
-		return GetPos().DistTo(Other);
+		Vector3 cPos;
+		GetPos(cPos);
+		return cPos.DistTo(Other);
 	}
+
+
+	//	CSCharModules
+	CSCharData* CharacterModules::GetCharData() { return this->pCharData; }
+	CSCharPhysics* CharacterModules::GetCharPhysics() { return this->pCharPhysics; }
+	CSPlayerDamage* CharacterModules::GetPlayerDamage() { return this->pPlayerDamage; }
+
+	//	CSCharData
+	int32_t CSCharData::GetHealth() { return this->CurrentHealth; }
+	void CSCharData::SetHealth(const int32_t& value) { this->CurrentHealth = value; }
+	int32_t CSCharData::GetMana() { return this->CurrentMana; }
+	void CSCharData::SetMana(const int32_t& value) { this->CurrentMana = value; }
+	int32_t CSCharData::GetStamina() { return this->CurrentStamina; }
+	void CSCharData::SetStamina(const int32_t& value) { this->CurrentStamina = value; }
+
+	//	CSCharPhysics
+	Vector3 CSCharPhysics::GetLocalPosition() { return this->RelativePosition; }
+	void CSCharPhysics::SetLocalPosition(Vector3 newPosition) { this->RelativePosition = newPosition; }
+	void CSCharPhysics::ToggleGravity() { this->bNoGravity ^= 1; }
 }
 #pragma pack(pop)

--- a/SDK/EldenRing_Structs.h
+++ b/SDK/EldenRing_Structs.h
@@ -2,6 +2,113 @@
 #pragma pack(push, 0x01)
 namespace HEXINTON
 {
+
+	class FaceData
+	{
+	public:
+		uint32_t            FaceModelId;
+		uint32_t            HairModelId;
+		uint32_t            EyeModelId;
+		uint32_t            EyebrowModelId;
+		uint32_t            BeardModelId;
+		uint32_t            AccModelId;
+		uint32_t            DecalModelId;
+		uint32_t            EyelashModelId;
+	};
+
+	struct ChrStats
+	{
+	public:
+		uint32_t            Vigor;                          // 0x0
+		uint32_t            Mind;                           // 0x4
+		uint32_t            Endurance;                      // 0x8
+		uint32_t            Strength;                       // 0xC
+		uint32_t            Dexterity;                      // 0x10
+		uint32_t            Intelligence;                   // 0x14
+		uint32_t            Faith;                          // 0x18
+		uint32_t            Arcane;                         // 0x1C
+	};
+
+	struct ChrAsm
+	{
+	public:
+		uint8_t             ArmStyle;                       // 0x328 (GameData + 0x328)
+		uint8_t             pad[3];                         // 0x329
+		uint32_t            CurrentWepSlotOffsetL;          // 0x32C
+		uint32_t            CurrentWepSlotOffsetR;          // 0x330
+		uint32_t            CurrentWepSlotOffsetLArrow;     // 0x334
+		uint32_t            CurrentWepSlotOffsetRArrow;     // 0x338
+		uint32_t            CurrentWepSlotOffsetLBolt;      // 0x33C
+		uint32_t            CurrentWepSlotOffsetRBolt;      // 0x340
+		char                pad2[0x44];                     // 0x344
+		uint32_t            Accessory1;                     // 0x388
+		uint32_t            Accessory2;                     // 0x38C
+		uint32_t            Accessory3;                     // 0x390
+		uint32_t            Accessory4;                     // 0x394
+		uint32_t            Accessory5;                     // 0x398
+		uint32_t            PrimaryWeaponL;                 // 0x39C
+		uint32_t            PrimaryWeaponR;                 // 0x3A0
+		uint32_t            SecondaryWeaponL;               // 0x3A4
+		uint32_t            SecondaryWeaponR;               // 0x3A8
+		uint32_t            TertiaryWeaponL;                // 0x3AC
+		uint32_t            TertiaryWeaponR;                // 0x3B0
+		uint32_t            PrimaryArrow;                   // 0x3B4
+		uint32_t            PrimaryBolt;                    // 0x3B8
+		uint32_t            SecondaryArrow;                 // 0x3BC
+		uint32_t            SecondaryBolt;                  // 0x3C0
+		uint32_t            TertiaryArrow;                  // 0x3C4
+		uint32_t            TertiaryBolt;                   // 0x3C8
+		uint32_t            Helmet;                         // 0x3CC
+		uint32_t            Chest;                          // 0x3D0
+		uint32_t            Gloves;                         // 0x3D4
+		uint32_t            Legs;                           // 0x3D8
+		uint32_t            Hair;                           // 0x3DC
+	};
+
+	class ChrGameData
+	{
+	public:
+		char                pad[0x10];                      // 0x0
+		uint32_t            Health;                         // 0x10
+		uint32_t            MaxHealth;                      // 0x14
+		uint32_t            BaseMaxHealth;                  // 0x18
+		uint32_t            Mana;                           // 0x1C
+		uint32_t            MaxMana;                        // 0x20
+		uint32_t            BaseMaxMana;                    // 0x24
+		uint32_t            unk;                            // 0x28
+		uint32_t            Stamina;                        // 0x2C
+		uint32_t            MaxStamina;                     // 0x30
+		uint32_t            BaseMaxStamina;                 // 0x34
+		uint32_t            unk_;                           // 0x38
+		class ChrStats      Stats;                          // 0x3C
+		int                 pad2[2];                        // 0x58
+		uint32_t            RuneArc;                        // 0x64
+		uint32_t            Level;                          // 0x68
+		uint32_t            CurrentRunes;                   // 0x6C
+		uint32_t            TotalRunes;                     // 0x70
+		int                 unk2;                           // 0x74
+		uint32_t            Immunity1;                      // 0x78
+		uint32_t            Immunity2;                      // 0x7C
+		uint32_t            Robustness;                     // 0x80
+		uint32_t            Vitality;                       // 0x84
+		uint32_t            Robustness2;                    // 0x88
+		uint32_t            Focus;                          // 0x8C
+		uint32_t            Focus2;                         // 0x90
+		int                 pad3[2];                        // 0x94
+		char                Name[19];                       // 0x9C
+		char                pad4[0xF];                      // 0xAF
+		PlayerGender		Gender;                         // 0xBE
+		PlayerClass			Class;                          // 0xBF
+		uint8_t             Appearance;                     // 0xC0
+		uint8_t             unk3;                           // 0xC1
+		uint8_t             Voice;                          // 0xC2
+		uint8_t             StartingGift;                   // 0xC3
+		char                pad5[0x3B];                     // 0xC4;
+		uint8_t             GreaterRuneState;               // 0xFF
+		char                unk_ad6[0x228];                 // 0x100
+		class ChrAsm        ChrAsm;                         // 0x328
+	};
+
     struct Alliance 
     {
 		int                 None = 0;
@@ -12,35 +119,6 @@ namespace HEXINTON
 		int                 Friendly = 26;
 		int                 Object = 30;
 	};
-
-	struct ChrObject 
-    {
-		char                pad_0000[8];	    //0x0000
-		int                 LOCALID;	        //0x0008
-		char                pad_000C[84];	    //0x000C
-		int                 PARAMID;	        //0x0060
-		char                pad_0064[8];	    //0x0064
-		char                ALLIANCE;	        //0x006C
-		char                pad_006D[7];	    //0x006D
-		unsigned __int16    GLOBALID;	        //0x0074
-		char                ad_0076[282];	    //0x0076
-		unsigned __int64    EntObjectPTR;	    //0x0190
-	};	//Size: 0x0198  
-
-	struct ChrData  
-    {   
-		char                pad_0000[312];	    //0x0000
-		int                 Health;	            //0x0138
-		int                 MaxHealth;	        //0x013C
-		int                 BaseMaxHealth;	    //0x0140
-		int                 unk;	            //0x0144
-		int                 Mana;	            //0x0148
-		int                 MaxMan;	            //0x014C
-		int                 BaseMaxMana;	    //0x0150
-		int                 Stamina;	        //0x0154
-		int                 MaxStamina;	        //0x0158
-		int                 BaseMaxStamina;	    //0x015C
-	};	//Size: 0x0160  
 
 	struct ChrFall  
     {   


### PR DESCRIPTION
# WorldCharManager Navigation
- Initialized SDK with offsets and auto class assigment
NOTE: WorldCharMan might initialize NULL
- Simplified WorldCharManager navigation

Example Source:
```cpp
// Initialize SDK
HEXINTON::InitSdk();

// Get World Char Man
auto worldCharMan = CGlobals::GWorldCharMan;

// Get Local Player
auto localPlayer = worldCharMan->GetLocalPlayer();

// Get Player Instance
auto playerInstance = localPlayer->GetPlayerInstance();

// Get char modules
auto charModules = playerInstance->GetCharacterModules();
	
// Get char data
auto charData = charModules->GetCharData();

// Set player health
charData->SetHealth(NULL);	// kills the local player
```